### PR TITLE
Add jQA Plugin identifcation including version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins{
     id 'maven-publish'
 }
 
-project.ext["jqaversion"] = "2.1.0"
+project.ext["jqaversion"] = "2.4.0"
 project.group = 'de.kontext-e.jqassistant.plugin'
 project.version = '2.2.2'
 
@@ -34,6 +34,15 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok:1.18.34'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
+}
+
+tasks.named('processResources') {
+    filesMatching('**/*.properties') {
+        expand(project.properties)
+    }
+    filesMatching('**/*.xml') {
+        expand(project.properties)
+    }
 }
 
 java {

--- a/src/main/resources/META-INF/jqassistant-plugin.xml
+++ b/src/main/resources/META-INF/jqassistant-plugin.xml
@@ -1,5 +1,9 @@
-<jqa-plugin:jqassistant-plugin
-        xmlns:jqa-plugin="http://www.buschmais.com/jqassistant/core/plugin/schema/v1.0" name="Git">
+<jqassistant-plugin xmlns="http://schema.jqassistant.org/plugin/v2.4"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://schema.jqassistant.org/plugin/v2.4 https://schema.jqassistant.org/plugin/jqassistant-plugin-v2.4.xsd"
+                    id="jqa.plugin.git"
+                    name="jQAssistant Git Plugin"
+                    version="${project.version}">
     <description>Provides a scanner for git VCS history.</description>
     <model>
         <class>de.kontext_e.jqassistant.plugin.git.store.descriptor.GitDescriptor</class>
@@ -19,4 +23,4 @@
     <rules>
         <resource>git.xml</resource>
     </rules>
-</jqa-plugin:jqassistant-plugin>
+</jqassistant-plugin>


### PR DESCRIPTION
Add jQA Plugin identifcation including version

to get a nice output when jQA loads the plugin.
Otherwise we will only see something like (e.g., in Maven)

  [INFO] Git <unknown version> [git]

Note that it was necessary to require

  jQA version 2.4.0

to get XML parsing right.
Newer jQA versions would require more changes.